### PR TITLE
v0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Added `moveKey` method to reassign a value from one key to another (renames the key while preserving the value).
+- Added `foreachKey` and `foreachValue` methods to iterate over all keys and values in the box
 
 ## 0.0.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added `moveKey` method to reassign a value from one key to another (renames the key while preserving the value).
 - Added `foreachKey` and `foreachValue` methods to iterate over all keys and values in the box
+- Made the base `BoxInterface` class simpler for better abstraction and flexibility
 
 ## 0.0.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-## Unreleased
+## 0.0.10
 
 - Added `moveKey` method to reassign a value from one key to another (renames the key while preserving the value).
 - Added `foreachKey` and `foreachValue` methods to iterate over all keys and values in the box
 - Made the base `BoxInterface` class simpler for better abstraction and flexibility
+- Added exports from `hive_ce` to the package for ease of use
+- Updated the **README** with more detailed examples and better structure with sections Features, Hive vs `Hivez` Comparison, How to Use `Hivez`, Examples, Setup Guide for `hive_ce`
 
 ## 0.0.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Added `moveKey` method to reassign a value from one key to another (renames the key while preserving the value).
+
 ## 0.0.9
 
 - Improved API structure, type safety and made unnecessary public members private

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ _[⤴️ Back](#table-of-contents) → Table of Contents_
 Hivez provides **four box types** that act as complete, self-initializing services for storing and managing data.  
 Unlike raw Hive, you don’t need to worry about opening/closing boxes — the API is unified and stays identical across box types.
 
+- [Which `Box` Should I Use?](#which-box-should-i-use)
+- [Available Methods](#-available-methods)
+- [Examples](#examples)
+
 ### Which `Box` Should I Use?
 
 - **`HivezBox`** → Default choice. Fast, synchronous reads with async writes.
@@ -155,6 +159,10 @@ All `HivezBox` types share the same complete API:
 
 ## Examples
 
+> Before diving in — make sure you’ve set up Hive correctly with adapters.  
+> The setup takes **less than 2 minutes** and is explained here: [Setup Guide](#-setup-guide-for-hive_ce).  
+> Once Hive is set up, you can use `Hivez` right away:
+
 #### ➕ Put & Get
 
 ```dart
@@ -166,7 +174,7 @@ final note = await box.get(1); // "Hello"
 #### 📥 Add & Retrieve by Index
 
 ```dart
-final id = await box.add('World');   // auto index
+final id = await box.add('World');   // auto index (int)
 final val = await box.getAt(id);     // "World"
 ```
 
@@ -228,7 +236,7 @@ box.watch(1).listen((event) {
 });
 ```
 
-> ✅ This is just with `HivezBox`.
+> ✅ This is just with `HivezBox`.  
 > The same API works for `HivezBoxLazy`, `HivezBoxIsolated`, and `HivezBoxIsolatedLazy`.
 
 _[⤴️ Back](#table-of-contents) → Table of Contents_

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![img](https://i.imgur.com/XgI3sfn.png)
 
-<h3 align="center"><i>Safe, synchronized and ready for production.</i></h3>
+<h3 align="center"><i>Hive, but safer, simpler, and smarter. Ready for production.</i></h3>
 <p align="center">
         <img src="https://img.shields.io/codefactor/grade/github/jozzdart/hivez/main?style=flat-square">
         <img src="https://img.shields.io/github/license/jozzdart/hivez?style=flat-square">
@@ -11,5 +11,277 @@
 <p align="center">
   <a href="https://buymeacoffee.com/yosefd99v" target="https://buymeacoffee.com/yosefd99v">
     <img src="https://img.shields.io/badge/Buy%20me%20a%20coffee-Support (:-blue?logo=buymeacoffee&style=flat-square" />
+  </a>
+</p>
+
+Meet `Hivez` — the smart, type-safe way to use **_Hive_** (using the [`hive_ce` package](https://pub.dev/packages/hive_ce)) in Dart and Flutter. With a unified API, zero setup, and built-in utilities for search, backups, and syncing, Hivez makes every box concurrency-safe, future-proof, and production-ready — while keeping full Hive compatibility.
+
+#### Table of Contents
+
+- [Features](#-features)
+- [Introduction](#-introduction)
+- [`Hive` vs `Hivez`](#-hive-vs-hivez)
+- [Introduction & Examples](#-introduction-&-examples)
+- [Setup Guide for `hive_ce`](#-setup-guide-for-hive_ce)
+- [Clean architecture with `Hivez`](#-clean-architecture-with-hivez)
+
+## ✅ Features
+
+- **Zero setup** – No manual `openBox` or init checks. Boxes auto-initialize on first use.
+- **Type-safe API** – No `dynamic`, no runtime surprises. Always the right types at compile time.
+- **Unified interface** – One clean API for `Box`, `LazyBox`, `IsolatedBox`, and `IsolatedLazyBox`. Swap implementations with a single line.
+- **Concurrency-safe** – Built-in locks ensure atomic writes and isolated reads under heavy async loads.
+- **Clean architecture ready** – Decouple storage from business logic with a consistent, testable interface.
+- **Production-grade** – Encryption, crash recovery, compaction, and path overrides included.
+- **Utility-rich** – Backup/restore (JSON), search helpers, iteration utilities, and full box management tools.
+- **Future-proof** – Start simple, scale later. Switch box types without rewriting your app logic.
+- **Fully compatible** – 100% Hive under the hood. All features supported, none removed.
+
+No `dynamic` (even for keys), no surprises.
+
+```dart
+final users = HivezBox<int, User>('users');
+await users.put(1, User('Alice'));
+final User? u = await users.get(1);
+```
+
+Zero Setup & Auto-Initialization, no more await `Hive.openBox`.
+
+```dart
+final settings = HivezBox<String, bool>('settings');
+await settings.put('darkMode', true); // no manual init
+final darkMode = await settings.get('darkMode');
+```
+
+**Unified API Across Box Types**  
+`Box`, `LazyBox`, `IsolatedBox` — all with one async interface.  
+Switch with a single line, your code stays the same.
+
+```dart
+final articles = HivezBoxLazy<String, Article>('articles');
+final articles = HivezBoxIsolated<String, Article>('articles');
+```
+
+# 🔄 `Hive` vs `Hivez`
+
+_[⤴️ Back](#table-of-contents) → Table of Contents_
+
+| Feature / Concern        | Native Hive                                         | With Hivez                                                                   |
+| ------------------------ | --------------------------------------------------- | ---------------------------------------------------------------------------- |
+| **Type Safety**          | Uses `dynamic`, requires manual casts               | Strongly typed: `HivezBox<int, User>` guarantees only `User` with `int` keys |
+| **Initialization**       | Must manually call `Hive.openBox` and check state   | Auto-initializes on first use, no boilerplate or crashes                     |
+| **API Consistency**      | Different APIs for `Box`, `LazyBox`, `IsolatedBox`  | Unified async API for all box types, switch with a single line               |
+| **Concurrency**          | Not concurrency-safe out of the box                 | Built-in locks: atomic writes, isolated reads, no race conditions            |
+| **Architecture**         | Logic tightly coupled with raw boxes                | Clean, abstracted interface ready for Clean Architecture & DI                |
+| **Utilities**            | Only basic CRUD                                     | Backup/restore (JSON), search helpers, iteration tools, box management       |
+| **Error Handling**       | Easy to get “Box not open” or type errors           | Guards built-in: no unsafe access, no unchecked casts                        |
+| **Production Readiness** | Good for small projects, needs extra care           | Encryption, crash recovery, compaction, isolated boxes — all supported       |
+| **Migration / Scaling**  | Switching to LazyBox/IsolatedBox requires rewriting | Swap `HivezBox` → `HivezBoxLazy` or `HivezBoxIsolated` without code changes  |
+| **Developer Experience** | Verbose, repetitive boilerplate                     | Cleaner, safer, future-proof abstraction with less code                      |
+
+# 📦 `HivezBox` API Overview
+
+[⤴️ Back](#table-of-contents) → Table of Contents
+
+Hivez provides **four box types** that act as complete, self-initializing services for storing and managing data.  
+Unlike raw Hive, you don’t need to worry about opening/closing boxes — the API is unified and stays identical across box types.
+
+### Which Box Should I Use?
+
+- **`HivezBox<K, T>`** → Default choice. Fast, synchronous reads with async writes.
+- **`HivezBoxLazy`** → Use when working with **large datasets** where values are only loaded on demand.
+- **`HivezBoxIsolated`** → Use when you need **isolate safety** (background isolates or heavy concurrency).
+- **`HivezBoxIsolatedLazy`** → Combine **lazy loading + isolate safety** for maximum scalability.
+
+> 💡 Switching between them is a **single-line change**. Your app logic and API calls stay exactly the same — while in raw Hive, this would break your code.
+
+## 🔧 Available Methods
+
+All `HivezBox` types share the same complete API:
+
+- **Write operations**
+
+  - `put(key, value)` — Insert or update a value by key
+  - `putAll(entries)` — Insert/update multiple entries at once
+  - `putAt(index, value)` — Update value at a specific index
+  - `add(value)` — Auto-increment key insert
+  - `addAll(values)` — Insert multiple values sequentially
+  - `moveKey(oldKey, newKey)` — Move value from one key to another
+
+- **Delete operations**
+
+  - `delete(key)` — Remove a value by key
+  - `deleteAt(index)` — Remove value at index
+  - `deleteAll(keys)` — Remove multiple keys
+  - `clear()` — Delete all data in the box
+
+- **Read operations**
+
+  - `get(key)` — Retrieve value by key (with optional `defaultValue`)
+  - `getAt(index)` — Retrieve value by index
+  - `valueAt(index)` — Alias for `getAt`
+  - `getAllKeys()` — Returns all keys
+  - `getAllValues()` — Returns all values
+  - `keyAt(index)` — Returns key at given index
+  - `containsKey(key)` — Check if key exists
+  - `length` — Number of items in box
+  - `isEmpty` / `isNotEmpty` — Quick state checks
+  - `watch(key)` — Listen to changes for a specific key
+
+- **Query helpers**
+
+  - `getValuesWhere(condition)` — Filter values by predicate
+  - `firstWhereOrNull(condition)` — Returns first matching value or `null`
+  - `firstWhereContains(query, searchableText)` — Search string fields
+  - `foreachKey(action)` — Iterate keys asynchronously
+  - `foreachValue(action)` — Iterate values asynchronously
+
+- **Box management**
+
+  - `ensureInitialized()` — Safely open box if not already open
+  - `deleteFromDisk()` — Permanently delete box data
+  - `closeBox()` — Close box in memory
+  - `flushBox()` — Write pending changes to disk
+  - `compactBox()` — Compact file to save space
+
+- **Extras**
+  - `toMap()` — Convert full box to `Map<K, T>` (non-lazy boxes)
+  - Backup/restore extensions — Export/import as JSON
+
+---
+
+⚡ In short: choose the box type once, and enjoy a **complete, type-safe, async API** everywhere.
+
+# 🔗 Setup Guide for `hive_ce`
+
+To start using Hive in Dart or Flutter, you’ll need the [Hive Community Edition](https://pub.dev/packages/hive_ce) (Hive CE) and the Flutter bindings.
+I made this setup guide for you to make it easier to get started with Hive.
+
+- [1. Add the packages](#1-add-the-packages)
+- [2. Setting Up `Hive` Adapters](#2-setting-up-hive-adapters)
+- [3. Registering Adapters](#3-registering-adapters)
+- [4. When Updating/Adding Types](#️-4-when-updatingadding-types)
+
+**It takes less than 2 minutes.**
+
+## 1. Add the packages
+
+One line command to add all packages:
+
+```sh
+flutter pub add hive_ce hive_ce_flutter dev:hive_ce_generator dev:build_runner
+```
+
+or add the following to your `pubspec.yaml` with the _latest_ versions:
+
+```yaml
+dependencies:
+  hive_ce: ^2.10.1
+  hive_ce_flutter: ^2.2.0
+
+dev_dependencies:
+  build_runner: ^2.4.7
+  hive_ce_generator: ^1.8.2
+```
+
+## 2. Setting Up `Hive` Adapters
+
+Hive works out of the box with core Dart types (`String`, `int`, `double`, `bool`, `DateTime`, `Uint8List`, `List`, `Map`…), but if you want to store **custom classes or enums**, you must register a **TypeAdapter**.
+
+With `Hive` you can generate multiple adapters at once with the `@GenerateAdapters` annotation. For all enums and classes you want to store, you need to register an adapter.
+
+Let's say you have the following classes and enums:
+
+```dart
+class Product {
+  final String name;
+  final double price;
+  final Category category;
+}
+```
+
+```dart
+enum Category {
+  electronics,
+  clothing,
+  books,
+  other,
+}
+```
+
+To generate the adapters, you need to:
+
+1. Create a folder named `hive` somewhere inside your `lib` folder
+2. Inside this `hive` folder create a file named `hive_adapters.dart`
+3. Add the following code to the file:
+
+```dart
+// hive/hive_adapters.dart
+import 'package:hive_ce/hive.dart';
+import '../product.dart';
+
+part 'hive_adapters.g.dart';
+
+@GenerateAdapters([
+  AdapterSpec<Product>(),
+  AdapterSpec<Category>(),
+])
+class HiveAdapters {}
+```
+
+Then run this command to generate the adapters:
+
+```sh
+dart run build_runner build --delete-conflicting-outputs
+```
+
+This creates the following files (do not delete/modify these files):
+
+```
+lib/hive/hive_adapters.g.dart
+lib/hive/hive_adapters.g.yaml
+lib/hive/hive_registrar.g.dart
+```
+
+## 3. Registering Adapters
+
+Then in main.dart before running the app, add the following code:
+Register adapters **before running the app**:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'hive/hive_registrar.g.dart'; // generated
+import 'product.dart';
+
+Future<void> main() async {
+  await Hive.initFlutter(); // Initialize Hive for Flutter
+  Hive.registerAdapters(); // Register all adapters in one line (Hive CE only)
+  runApp(const MyApp());
+}
+```
+
+Done! You can now use the `Hivez` package to store and retrieve custom objects.
+
+### ⚠️ 4. When Updating/Adding Types
+
+If you add new classes or enums, or change existing ones (like adding fields or updating behavior),  
+just include them in your `hive_adapters.dart` file and re-run the build command:
+
+```sh
+dart run build_runner build --delete-conflicting-outputs
+```
+
+That’s it — Hive will regenerate the adapters automatically.
+
+_[⤴️ Back](#table-of-contents) → Table of Contents_
+
+## 👋🏻 Introduction
+
+## 🔗 License MIT © Jozz
+
+<p align="center">
+  <a href="https://buymeacoffee.com/yosefd99v" target="https://buymeacoffee.com/yosefd99v">
+    ☕ Enjoying this package? You can support it here.
   </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -19,81 +19,81 @@ Meet `Hivez` — the smart, type-safe way to use **_Hive_** (using the [`hive_ce
 #### Table of Contents
 
 - [Features](#-features)
-- [Introduction](#-introduction)
-- [`Hive` vs `Hivez`](#-hive-vs-hivez)
-- [Introduction & Examples](#-introduction-&-examples)
+- [Hive vs `Hivez` Comparison](#hive-vs-hivez)
+- [How to Use `Hivez`](#-how-to-use-hivez)
+  - [Which `Box` Should I Use?](#which-box-should-i-use)
+  - [Available Methods](#-available-methods)
+  - [Examples](#examples)
 - [Setup Guide for `hive_ce`](#-setup-guide-for-hive_ce)
 - [Clean architecture with `Hivez`](#-clean-architecture-with-hivez)
 
 ## ✅ Features
 
-- **Zero setup** – No manual `openBox` or init checks. Boxes auto-initialize on first use.
-- **Type-safe API** – No `dynamic`, no runtime surprises. Always the right types at compile time.
-- **Unified interface** – One clean API for `Box`, `LazyBox`, `IsolatedBox`, and `IsolatedLazyBox`. Swap implementations with a single line.
-- **Concurrency-safe** – Built-in locks ensure atomic writes and isolated reads under heavy async loads.
-- **Clean architecture ready** – Decouple storage from business logic with a consistent, testable interface.
-- **Production-grade** – Encryption, crash recovery, compaction, and path overrides included.
-- **Utility-rich** – Backup/restore (JSON), search helpers, iteration utilities, and full box management tools.
-- **Future-proof** – Start simple, scale later. Switch box types without rewriting your app logic.
-- **Fully compatible** – 100% Hive under the hood. All features supported, none removed.
+- **Zero setup** – no manual `openBox`, auto-init on first use
+- **Type-safe** – no `dynamic`, compile-time guarantees
+- **Unified API** – one interface for Box, Lazy, Isolated
+- **Concurrency-safe** – atomic writes, safe reads
+- **Clean architecture** – decoupled, testable design
+- **Production-ready** – encryption, crash recovery, compaction
+- **Utility-rich** – backup/restore, search, iteration, box tools
+- **Future-proof** – swap box types with one line
+- **Hive-compatible** – 100% features, zero loss
 
-No `dynamic` (even for keys), no surprises.
+**Type-safe** – no `dynamic`, no surprises
 
 ```dart
 final users = HivezBox<int, User>('users');
 await users.put(1, User('Alice'));
-final User? u = await users.get(1);
+final u = await users.get(1); // User('Alice')
 ```
 
-Zero Setup & Auto-Initialization, no more await `Hive.openBox`.
+**Zero setup** – no `openBox`, auto-init on first use
 
 ```dart
 final settings = HivezBox<String, bool>('settings');
-await settings.put('darkMode', true); // no manual init
-final darkMode = await settings.get('darkMode');
+await settings.put('darkMode', true);
+final dark = await settings.get('darkMode'); // true
 ```
 
-**Unified API Across Box Types**  
-`Box`, `LazyBox`, `IsolatedBox` — all with one async interface.  
-Switch with a single line, your code stays the same.
+**Unified API** – Box, Lazy, Isolated — same interface, swap with one line
 
 ```dart
-final articles = HivezBoxLazy<String, Article>('articles');
-final articles = HivezBoxIsolated<String, Article>('articles');
+final a = HivezBoxLazy<String, Article>('articles');
+final b = HivezBoxIsolated<String, Article>('articles');
 ```
 
-# 🔄 `Hive` vs `Hivez`
+# Hive vs `Hivez`
 
 _[⤴️ Back](#table-of-contents) → Table of Contents_
 
-| Feature / Concern        | Native Hive                                         | With Hivez                                                                   |
-| ------------------------ | --------------------------------------------------- | ---------------------------------------------------------------------------- |
-| **Type Safety**          | Uses `dynamic`, requires manual casts               | Strongly typed: `HivezBox<int, User>` guarantees only `User` with `int` keys |
-| **Initialization**       | Must manually call `Hive.openBox` and check state   | Auto-initializes on first use, no boilerplate or crashes                     |
-| **API Consistency**      | Different APIs for `Box`, `LazyBox`, `IsolatedBox`  | Unified async API for all box types, switch with a single line               |
-| **Concurrency**          | Not concurrency-safe out of the box                 | Built-in locks: atomic writes, isolated reads, no race conditions            |
-| **Architecture**         | Logic tightly coupled with raw boxes                | Clean, abstracted interface ready for Clean Architecture & DI                |
-| **Utilities**            | Only basic CRUD                                     | Backup/restore (JSON), search helpers, iteration tools, box management       |
-| **Error Handling**       | Easy to get “Box not open” or type errors           | Guards built-in: no unsafe access, no unchecked casts                        |
-| **Production Readiness** | Good for small projects, needs extra care           | Encryption, crash recovery, compaction, isolated boxes — all supported       |
-| **Migration / Scaling**  | Switching to LazyBox/IsolatedBox requires rewriting | Swap `HivezBox` → `HivezBoxLazy` or `HivezBoxIsolated` without code changes  |
-| **Developer Experience** | Verbose, repetitive boilerplate                     | Cleaner, safer, future-proof abstraction with less code                      |
+| Feature / Concern   | Native Hive                              | With Hivez                                                      |
+| ------------------- | ---------------------------------------- | --------------------------------------------------------------- |
+| **Type Safety**     | `dynamic` with manual casts              | `HivezBox<int, User>` guarantees correct types                  |
+| **Initialization**  | Must call `Hive.openBox` and check state | Auto-initializes on first use, no boilerplate                   |
+| **API Consistency** | Different APIs for Box types             | Unified async API, switch with a single line                    |
+| **Concurrency**     | Not concurrency-safe                     | Built-in locks: atomic writes, safe reads                       |
+| **Architecture**    | Logic tied to raw boxes                  | Abstracted interface, fits Clean Architecture & DI              |
+| **Utilities**       | Basic CRUD only                          | Backup/restore, search helpers, iteration, box management       |
+| **Production**      | Needs extra care for scaling & safety    | Encryption, crash recovery, compaction, isolated boxes included |
+| **Migration**       | Switching box types requires rewrites    | Swap `HivezBox` ↔ `HivezBoxLazy`/`HivezBoxIsolated` seamlessly  |
+| **Dev Experience**  | Verbose boilerplate, error-prone         | Cleaner, safer, future-proof, less code                         |
 
-# 📦 `HivezBox` API Overview
+# 📦 How to Use `Hivez`
 
 [⤴️ Back](#table-of-contents) → Table of Contents
 
 Hivez provides **four box types** that act as complete, self-initializing services for storing and managing data.  
 Unlike raw Hive, you don’t need to worry about opening/closing boxes — the API is unified and stays identical across box types.
 
-### Which Box Should I Use?
+### Which `Box` Should I Use?
 
-- **`HivezBox<K, T>`** → Default choice. Fast, synchronous reads with async writes.
+- **`HivezBox`** → Default choice. Fast, synchronous reads with async writes.
 - **`HivezBoxLazy`** → Use when working with **large datasets** where values are only loaded on demand.
 - **`HivezBoxIsolated`** → Use when you need **isolate safety** (background isolates or heavy concurrency).
 - **`HivezBoxIsolatedLazy`** → Combine **lazy loading + isolate safety** for maximum scalability.
 
-> 💡 Switching between them is a **single-line change**. Your app logic and API calls stay exactly the same — while in raw Hive, this would break your code.
+> 💡 Switching between them is a **single-line change**. Your app logic and API calls stay exactly the same — while in raw Hive, this would break your code.  
+> ⚠️ **Note on isolates:** The API is identical across all box types, but using `Isolated` boxes requires you to properly set up Hive with isolates. If you’re not familiar with isolate management in Dart/Flutter, it’s safer to stick with **`HivezBox`** or **`HivezBoxLazy`**.
 
 ## 🔧 Available Methods
 
@@ -145,12 +145,93 @@ All `HivezBox` types share the same complete API:
   - `compactBox()` — Compact file to save space
 
 - **Extras**
+
+  - `generateBackupJson()` — Export all data as JSON
+  - `restoreBackupJson()` — Import all data from JSON
+  - `generateBackupCompressed()` — Export all data as compressed binary
+  - `restoreBackupCompressed()` — Import all data from compressed binary
   - `toMap()` — Convert full box to `Map<K, T>` (non-lazy boxes)
-  - Backup/restore extensions — Export/import as JSON
+  - `search(query, searchableText, {page, pageSize, sortBy})` — Full-text search with optional pagination & sorting
 
----
+## Examples
 
-⚡ In short: choose the box type once, and enjoy a **complete, type-safe, async API** everywhere.
+#### ➕ Put & Get
+
+```dart
+final box = HivezBox<int, String>('notes');
+await box.put(1, 'Hello');
+final note = await box.get(1); // "Hello"
+```
+
+#### 📥 Add & Retrieve by Index
+
+```dart
+final id = await box.add('World');   // auto index
+final val = await box.getAt(id);     // "World"
+```
+
+#### ✏️ Update & Move Keys
+
+```dart
+await box.put(1, 'Updated');
+await box.moveKey(1, 2); // value moved from key 1 → key 2
+```
+
+#### ❌ Delete & Clear
+
+```dart
+await box.delete(2);
+await box.clear(); // remove all
+```
+
+#### 🔑 Keys & Values
+
+```dart
+final keys = await box.getAllKeys();     // Iterable<int>
+final vals = await box.getAllValues();  // Iterable<String>
+```
+
+#### 🔍 Queries
+
+```dart
+final match = await box.firstWhereOrNull((v) => v.contains('Hello'));
+final contains = await box.containsKey(1); // true / false
+```
+
+#### 🔄 Iteration Helpers
+
+```dart
+await box.foreachKey((k) async => print(k));
+await box.foreachValue((k, v) async => print('$k:$v'));
+```
+
+#### 📊 Box Info
+
+```dart
+final count = await box.length;
+final empty = await box.isEmpty;
+```
+
+#### ⚡ Utilities
+
+```dart
+await box.flushBox();    // write to disk
+await box.compactBox();  // shrink file
+await box.deleteFromDisk(); // remove permanently
+```
+
+#### 👀 Watch for Changes
+
+```dart
+box.watch(1).listen((event) {
+  print('Key changed: ${event.key}');
+});
+```
+
+> ✅ This is just with `HivezBox`.
+> The same API works for `HivezBoxLazy`, `HivezBoxIsolated`, and `HivezBoxIsolatedLazy`.
+
+_[⤴️ Back](#table-of-contents) → Table of Contents_
 
 # 🔗 Setup Guide for `hive_ce`
 
@@ -169,14 +250,14 @@ I made this setup guide for you to make it easier to get started with Hive.
 One line command to add all packages:
 
 ```sh
-flutter pub add hive_ce hive_ce_flutter dev:hive_ce_generator dev:build_runner
+flutter pub add hive_ce_flutter hivez dev:hive_ce_generator dev:build_runner
 ```
 
 or add the following to your `pubspec.yaml` with the _latest_ versions:
 
 ```yaml
 dependencies:
-  hive_ce: ^2.10.1
+  hivez: ^1.0.0
   hive_ce_flutter: ^2.2.0
 
 dev_dependencies:

--- a/lib/hivez.dart
+++ b/lib/hivez.dart
@@ -1,3 +1,5 @@
 library;
 
 export 'src/src.dart';
+export 'package:hive_ce/hive.dart'
+    show Hive, IsolatedHive, HiveCipher, BoxEvent, HiveAesCipher;

--- a/lib/src/boxes/base_box.dart
+++ b/lib/src/boxes/base_box.dart
@@ -2,7 +2,7 @@ part of 'boxes.dart';
 
 typedef LogHandler = void Function(String message);
 
-abstract class BoxInterface<K, T, BoxType> {
+abstract class BoxInterface<K, T> {
   final String name;
   final HiveCipher? _encryptionCipher;
   final bool _crashRecovery;
@@ -26,7 +26,6 @@ abstract class BoxInterface<K, T, BoxType> {
   bool get isIsolated;
   bool get isLazy;
 
-  BoxType get box;
   String? get path;
 
   Future<bool> get isEmpty;
@@ -73,14 +72,17 @@ abstract class BoxInterface<K, T, BoxType> {
   Future<void> closeBox();
   Future<void> flushBox();
   Future<void> compactBox();
-
-  // Helper functions
-  BoxType _getExistingBox();
-  Future<BoxType> _openBox();
-  bool get _isOpenInHive;
 }
 
-abstract class BaseHivezBox<K, T, B> extends BoxInterface<K, T, B> {
+abstract class _BoxInterfaceHelpers<K, T, BoxType> {
+  BoxType get box;
+  bool get _isOpenInHive;
+  BoxType _getExistingBox();
+  Future<BoxType> _openBox();
+}
+
+abstract class BaseHivezBox<K, T, B> extends BoxInterface<K, T>
+    implements _BoxInterfaceHelpers<K, T, B> {
   final LogHandler? _logger;
   final Lock _initLock = Lock();
   final Lock _lock = Lock();

--- a/lib/src/boxes/base_box.dart
+++ b/lib/src/boxes/base_box.dart
@@ -187,24 +187,28 @@ abstract class BaseHivezBox<K, T, B> extends BoxInterface<K, T, B> {
   }
 
   @override
-  Future<void> foreachKey(Future<void> Function(K key) action) async {
+  Future<void> foreachKey(Future<void> Function(K key) action,
+      {bool Function()? breakCondition}) async {
     await _executeRead(() async {
       final keys = await getAllKeys();
       for (final key in keys) {
         await action(key);
+        if (breakCondition != null && breakCondition()) {
+          return;
+        }
       }
     });
   }
 
   @override
-  Future<void> foreachValue(
-      Future<void> Function(K key, T value) action) async {
+  Future<void> foreachValue(Future<void> Function(K key, T value) action,
+      {bool Function()? breakCondition}) async {
     await foreachKey((key) async {
       final value = await get(key);
       if (value != null) {
         await action(key, value);
       }
-    });
+    }, breakCondition: breakCondition);
   }
 }
 

--- a/lib/src/extensions/backup_compressed.dart
+++ b/lib/src/extensions/backup_compressed.dart
@@ -1,9 +1,8 @@
 import 'dart:typed_data';
 import 'package:hivez/hivez.dart';
-import 'package:hivez/src/boxes/boxes.dart';
 import 'package:shrink/shrink.dart';
 
-extension BackupCompressedExtension<K, T, B> on BoxInterface<K, T, B> {
+extension BackupCompressedExtension<K, T> on BoxInterface<K, T> {
   Future<Uint8List> generateBackupCompressed({
     String Function(K key)? keyToString,
     Object? Function(T value)? valueToJson,

--- a/lib/src/extensions/backup_json.dart
+++ b/lib/src/extensions/backup_json.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 import 'package:hivez/src/boxes/boxes.dart';
 
-extension BackupJsonExtension<K, T, B> on BoxInterface<K, T, B> {
+extension BackupJsonExtension<K, T> on BoxInterface<K, T> {
   Future<String> generateBackupJson({
     String Function(K key)? keyToString,
     Object? Function(T value)? valueToJson,

--- a/lib/src/extensions/search.dart
+++ b/lib/src/extensions/search.dart
@@ -1,6 +1,6 @@
 import 'package:hivez/src/boxes/boxes.dart';
 
-extension SearchExtensionMethod<K, T, B> on BoxInterface<K, T, B> {
+extension SearchExtensionMethod<K, T> on BoxInterface<K, T> {
   Future<List<T>> search({
     required String query,
     required String Function(T item) searchableText,

--- a/lib/src/src.dart
+++ b/lib/src/src.dart
@@ -1,3 +1,9 @@
 export 'boxes/boxes.dart'
-    show HivezBox, HivezBoxLazy, HivezBoxIsolated, HivezBoxIsolatedLazy;
+    show
+        HivezBox,
+        HivezBoxLazy,
+        HivezBoxIsolated,
+        HivezBoxIsolatedLazy,
+        BaseHivezBox,
+        BoxInterface;
 export 'extensions/extensions.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: hivez
 description: "The cleanest way to use Hive in production. Type-safe, concurrency-safe, boilerplate-free. (Using hive_ce)"
-version: 0.0.9
+version: 0.0.10
 homepage: https://github.com/jozzdart/hivez
 repository: https://github.com/jozzdart/hivez
 issue_tracker: https://github.com/jozzdart/hivez/issues
@@ -15,7 +15,7 @@ environment:
 
 dependencies:
   collection: ^1.19.1
-  hive_ce: ^2.13.2
+  hive_ce: ^2.11.3
   meta: ^1.16.0
   shrink: ^1.5.12
   synchronized: ^3.2.0

--- a/test/boxes/hivez_box_lazy_test.dart
+++ b/test/boxes/hivez_box_lazy_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hive_ce_flutter/adapters.dart';
 
 import '../utils/test_setup.dart';
 

--- a/test/boxes/hivez_box_lazy_test.dart
+++ b/test/boxes/hivez_box_lazy_test.dart
@@ -173,6 +173,100 @@ void main() {
     await box2.deleteFromDisk();
   });
 
+  test('foreachKey visits all keys exactly once and in order', () async {
+    await hivezBox.clear();
+    final entries = <int, int>{};
+    for (var i = 0; i < 120; i++) {
+      entries[i] = i * 3;
+    }
+    await hivezBox.putAll(entries);
+
+    final visitedKeys = <int>[];
+    await hivezBox.foreachKey((key) async {
+      visitedKeys.add(key);
+    });
+
+    final allKeys = (await hivezBox.getAllKeys()).toList();
+    expect(visitedKeys, allKeys);
+    expect(visitedKeys.toSet(), allKeys.toSet());
+  });
+
+  test('foreachValue accumulates sum over many entries', () async {
+    await hivezBox.clear();
+    final entries = <int, int>{};
+    var expectedSum = 0;
+    for (var i = 1; i <= 750; i++) {
+      entries[i] = i;
+      expectedSum += i;
+    }
+    await hivezBox.putAll(entries);
+
+    var sum = 0;
+    await hivezBox.foreachValue((key, value) async {
+      sum += value;
+    });
+    expect(sum, expectedSum);
+  });
+
+  test('foreachValue skips null values for nullable lazy box type', () async {
+    final box = HivezBoxLazy<int, String?>('nullableLazyBox');
+    await box.ensureInitialized();
+    await box.clear();
+    await box.putAll({
+      1: 'a',
+      2: null,
+      3: 'c',
+      4: null,
+      5: 'e',
+    });
+
+    final seen = <int, String>{};
+    await box.foreachValue((key, value) async {
+      seen[key] = value!;
+    });
+
+    expect(seen.keys.toSet(), {1, 3, 5});
+    expect(seen.values.toSet(), {'a', 'c', 'e'});
+
+    await Hive.deleteBoxFromDisk('nullableLazyBox');
+  });
+
+  test('foreachKey preserves initial order; may include new keys appended',
+      () async {
+    await hivezBox.clear();
+    await hivezBox.putAll({0: 0, 1: 10, 2: 20, 3: 30});
+
+    final visited = <int>[];
+    await hivezBox.foreachKey((key) async {
+      visited.add(key);
+      if (key == 1) {
+        await hivezBox.put(999, 999);
+      }
+    });
+    expect(visited.take(4).toList(), [0, 1, 2, 3]);
+    expect(visited.length, anyOf(4, 5));
+    if (visited.length == 5) {
+      expect(visited.last, 999);
+    }
+    expect(await hivezBox.containsKey(999), isTrue);
+  });
+
+  test('foreachKey propagates exceptions from action and stops iteration',
+      () async {
+    await hivezBox.clear();
+    await hivezBox.putAll({0: 0, 1: 10, 2: 20, 3: 30});
+
+    var count = 0;
+    Future<void> run() => hivezBox.foreachKey((key) async {
+          count++;
+          if (key == 2) throw StateError('boom');
+        });
+
+    await expectLater(run(), throwsA(isA<StateError>()));
+    expect(count, lessThan(4));
+    expect(count, greaterThanOrEqualTo(3));
+  });
+
   test('moveKey moves value to new key and removes old key', () async {
     await hivezBox.putAll({1: 10});
     final ok = await hivezBox.moveKey(1, 2);

--- a/test/boxes/hivez_box_lazy_test.dart
+++ b/test/boxes/hivez_box_lazy_test.dart
@@ -172,4 +172,30 @@ void main() {
     expect(await box2.length, 0);
     await box2.deleteFromDisk();
   });
+
+  test('moveKey moves value to new key and removes old key', () async {
+    await hivezBox.putAll({1: 10});
+    final ok = await hivezBox.moveKey(1, 2);
+    expect(ok, isTrue);
+    expect(await hivezBox.containsKey(1), isFalse);
+    expect(await hivezBox.get(2), 10);
+    expect(await hivezBox.length, 1);
+  });
+
+  test('moveKey returns false for missing old key', () async {
+    await hivezBox.putAll({5: 50});
+    final ok = await hivezBox.moveKey(1, 2);
+    expect(ok, isFalse);
+    expect(await hivezBox.containsKey(5), isTrue);
+    expect(await hivezBox.length, 1);
+  });
+
+  test('moveKey overwrites value if new key exists', () async {
+    await hivezBox.putAll({1: 10, 2: 99});
+    final ok = await hivezBox.moveKey(1, 2);
+    expect(ok, isTrue);
+    expect(await hivezBox.containsKey(1), isFalse);
+    expect(await hivezBox.get(2), 10);
+    expect(await hivezBox.length, 1);
+  });
 }

--- a/test/boxes/hivez_box_test.dart
+++ b/test/boxes/hivez_box_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hive_ce_flutter/adapters.dart';
 
 import '../utils/test_setup.dart';
 

--- a/test/boxes/hivez_box_test.dart
+++ b/test/boxes/hivez_box_test.dart
@@ -214,4 +214,101 @@ void main() {
     expect(await hivezBox.get(2), 10);
     expect(await hivezBox.length, 1);
   });
+
+  test('foreachKey visits all keys exactly once and in order', () async {
+    await hivezBox.clear();
+    final entries = <int, int>{};
+    for (var i = 0; i < 100; i++) {
+      entries[i] = i * 2;
+    }
+    await hivezBox.putAll(entries);
+
+    final visitedKeys = <int>[];
+    await hivezBox.foreachKey((key) async {
+      visitedKeys.add(key);
+    });
+
+    final allKeys = (await hivezBox.getAllKeys()).toList();
+    expect(visitedKeys, allKeys);
+    expect(visitedKeys.toSet(), allKeys.toSet());
+  });
+
+  test('foreachValue accumulates sum over many entries', () async {
+    await hivezBox.clear();
+    final entries = <int, int>{};
+    var expectedSum = 0;
+    for (var i = 1; i <= 1000; i++) {
+      entries[i] = i;
+      expectedSum += i;
+    }
+    await hivezBox.putAll(entries);
+
+    var sum = 0;
+    await hivezBox.foreachValue((key, value) async {
+      sum += value;
+    });
+    expect(sum, expectedSum);
+  });
+
+  test('foreachValue skips null values for nullable box type', () async {
+    final box = HivezBox<int, String?>('nullableBox');
+    await box.ensureInitialized();
+    await box.clear();
+    await box.putAll({
+      1: 'a',
+      2: null,
+      3: 'c',
+      4: null,
+      5: 'e',
+    });
+
+    final seen = <int, String>{};
+    await box.foreachValue((key, value) async {
+      seen[key] = value!;
+    });
+
+    expect(seen.keys.toSet(), {1, 3, 5});
+    expect(seen.values.toSet(), {'a', 'c', 'e'});
+
+    await box.deleteFromDisk();
+  });
+
+  test('foreachKey preserves initial order; may include new keys appended',
+      () async {
+    await hivezBox.clear();
+    await hivezBox.putAll({0: 0, 1: 10, 2: 20, 3: 30});
+
+    final visited = <int>[];
+    await hivezBox.foreachKey((key) async {
+      visited.add(key);
+      if (key == 1) {
+        // mutate: add a new key; should not be visited in this iteration
+        await hivezBox.put(999, 999);
+      }
+    });
+    // Initial keys should remain in order
+    expect(visited.take(4).toList(), [0, 1, 2, 3]);
+    // Some backends include newly added keys at the end during iteration
+    expect(visited.length, anyOf(4, 5));
+    if (visited.length == 5) {
+      expect(visited.last, 999);
+    }
+    expect(await hivezBox.containsKey(999), isTrue);
+  });
+
+  test('foreachKey propagates exceptions from action and stops iteration',
+      () async {
+    await hivezBox.clear();
+    await hivezBox.putAll({0: 0, 1: 10, 2: 20, 3: 30});
+
+    var count = 0;
+    Future<void> run() => hivezBox.foreachKey((key) async {
+          count++;
+          if (key == 2) throw StateError('boom');
+        });
+
+    await expectLater(run(), throwsA(isA<StateError>()));
+    expect(count, lessThan(4));
+    expect(count, greaterThanOrEqualTo(3)); // 0,1,2 visited
+  });
 }

--- a/test/boxes/hivez_box_test.dart
+++ b/test/boxes/hivez_box_test.dart
@@ -188,4 +188,30 @@ void main() {
     expect(await box2.length, 0);
     await box2.deleteFromDisk();
   });
+
+  test('moveKey moves value to new key and removes old key', () async {
+    await hivezBox.putAll({1: 10});
+    final ok = await hivezBox.moveKey(1, 2);
+    expect(ok, isTrue);
+    expect(await hivezBox.containsKey(1), isFalse);
+    expect(await hivezBox.get(2), 10);
+    expect(await hivezBox.length, 1);
+  });
+
+  test('moveKey returns false for missing old key', () async {
+    await hivezBox.putAll({5: 50});
+    final ok = await hivezBox.moveKey(1, 2);
+    expect(ok, isFalse);
+    expect(await hivezBox.containsKey(5), isTrue);
+    expect(await hivezBox.length, 1);
+  });
+
+  test('moveKey overwrites value if new key exists', () async {
+    await hivezBox.putAll({1: 10, 2: 99});
+    final ok = await hivezBox.moveKey(1, 2);
+    expect(ok, isTrue);
+    expect(await hivezBox.containsKey(1), isFalse);
+    expect(await hivezBox.get(2), 10);
+    expect(await hivezBox.length, 1);
+  });
 }

--- a/test/boxes/hivez_isolated_lazy_test.dart
+++ b/test/boxes/hivez_isolated_lazy_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+// ignore: unnecessary_import
 import 'package:hive_ce_flutter/adapters.dart';
 
 import '../utils/test_setup.dart';

--- a/test/boxes/hivez_isolated_lazy_test.dart
+++ b/test/boxes/hivez_isolated_lazy_test.dart
@@ -173,4 +173,30 @@ void main() {
     expect(await box2.length, 0);
     await box2.deleteFromDisk();
   });
+
+  test('moveKey moves value to new key and removes old key', () async {
+    await hivezBox.putAll({1: 10});
+    final ok = await hivezBox.moveKey(1, 2);
+    expect(ok, isTrue);
+    expect(await hivezBox.containsKey(1), isFalse);
+    expect(await hivezBox.get(2), 10);
+    expect(await hivezBox.length, 1);
+  });
+
+  test('moveKey returns false for missing old key', () async {
+    await hivezBox.putAll({5: 50});
+    final ok = await hivezBox.moveKey(1, 2);
+    expect(ok, isFalse);
+    expect(await hivezBox.containsKey(5), isTrue);
+    expect(await hivezBox.length, 1);
+  });
+
+  test('moveKey overwrites value if new key exists', () async {
+    await hivezBox.putAll({1: 10, 2: 99});
+    final ok = await hivezBox.moveKey(1, 2);
+    expect(ok, isTrue);
+    expect(await hivezBox.containsKey(1), isFalse);
+    expect(await hivezBox.get(2), 10);
+    expect(await hivezBox.length, 1);
+  });
 }

--- a/test/boxes/hivez_isolated_lazy_test.dart
+++ b/test/boxes/hivez_isolated_lazy_test.dart
@@ -174,6 +174,98 @@ void main() {
     await box2.deleteFromDisk();
   });
 
+  test('foreachKey visits all keys exactly once and in order', () async {
+    await hivezBox.clear();
+    final entries = <int, int>{};
+    for (var i = 0; i < 160; i++) {
+      entries[i] = i * 5;
+    }
+    await hivezBox.putAll(entries);
+
+    final visitedKeys = <int>[];
+    await hivezBox.foreachKey((key) async {
+      visitedKeys.add(key);
+    });
+
+    final allKeys = (await hivezBox.getAllKeys()).toList();
+    expect(visitedKeys, allKeys);
+    expect(visitedKeys.toSet(), allKeys.toSet());
+  });
+
+  test('foreachValue accumulates sum over many entries', () async {
+    await hivezBox.clear();
+    final entries = <int, int>{};
+    var expectedSum = 0;
+    for (var i = 1; i <= 650; i++) {
+      entries[i] = i;
+      expectedSum += i;
+    }
+    await hivezBox.putAll(entries);
+
+    var sum = 0;
+    await hivezBox.foreachValue((key, value) async {
+      sum += value;
+    });
+    expect(sum, expectedSum);
+  });
+
+  test('foreachValue skips null values for nullable isolated lazy box type',
+      () async {
+    final box = HivezBoxIsolatedLazy<int, String?>('nullableIsoLazyBox');
+    await box.ensureInitialized();
+    await box.clear();
+    await box.putAll({
+      1: 'a',
+      2: null,
+      3: 'c',
+      4: null,
+      5: 'e',
+    });
+
+    final seen = <int, String>{};
+    await box.foreachValue((key, value) async {
+      seen[key] = value!;
+    });
+
+    expect(seen.keys.toSet(), {1, 3, 5});
+    expect(seen.values.toSet(), {'a', 'c', 'e'});
+
+    await IsolatedHive.deleteBoxFromDisk('nullableIsoLazyBox');
+  });
+
+  test('foreachKey snapshot is stable across mid-iteration mutations',
+      () async {
+    await hivezBox.clear();
+    await hivezBox.putAll({0: 0, 1: 10, 2: 20, 3: 30});
+
+    final visited = <int>[];
+    await hivezBox.foreachKey((key) async {
+      visited.add(key);
+      if (key == 1) {
+        await hivezBox.put(999, 999);
+      }
+    });
+
+    expect(visited, [0, 1, 2, 3]);
+    expect(await hivezBox.containsKey(999), isTrue);
+  });
+
+  test('foreachKey propagates exceptions from action and stops iteration',
+      () async {
+    await hivezBox.clear();
+    await hivezBox.putAll({0: 0, 1: 10, 2: 20, 3: 30});
+
+    var count = 0;
+    Future<void> run() => hivezBox.foreachKey((key) async {
+          count++;
+          if (key == 2) throw StateError('boom');
+        });
+
+    await expectLater(run(), throwsA(isA<StateError>()));
+    expect(count, lessThan(4));
+    expect(count, greaterThanOrEqualTo(3));
+  });
+
   test('moveKey moves value to new key and removes old key', () async {
     await hivezBox.putAll({1: 10});
     final ok = await hivezBox.moveKey(1, 2);

--- a/test/boxes/hivez_isolated_test.dart
+++ b/test/boxes/hivez_isolated_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hive_ce_flutter/adapters.dart';
 
 import '../utils/test_setup.dart';
 

--- a/test/boxes/hivez_isolated_test.dart
+++ b/test/boxes/hivez_isolated_test.dart
@@ -173,4 +173,30 @@ void main() {
     expect(await box2.length, 0);
     await box2.deleteFromDisk();
   });
+
+  test('moveKey moves value to new key and removes old key', () async {
+    await hivezBox.putAll({1: 10});
+    final ok = await hivezBox.moveKey(1, 2);
+    expect(ok, isTrue);
+    expect(await hivezBox.containsKey(1), isFalse);
+    expect(await hivezBox.get(2), 10);
+    expect(await hivezBox.length, 1);
+  });
+
+  test('moveKey returns false for missing old key', () async {
+    await hivezBox.putAll({5: 50});
+    final ok = await hivezBox.moveKey(1, 2);
+    expect(ok, isFalse);
+    expect(await hivezBox.containsKey(5), isTrue);
+    expect(await hivezBox.length, 1);
+  });
+
+  test('moveKey overwrites value if new key exists', () async {
+    await hivezBox.putAll({1: 10, 2: 99});
+    final ok = await hivezBox.moveKey(1, 2);
+    expect(ok, isTrue);
+    expect(await hivezBox.containsKey(1), isFalse);
+    expect(await hivezBox.get(2), 10);
+    expect(await hivezBox.length, 1);
+  });
 }

--- a/test/boxes/hivez_isolated_test.dart
+++ b/test/boxes/hivez_isolated_test.dart
@@ -174,6 +174,101 @@ void main() {
     await box2.deleteFromDisk();
   });
 
+  test('foreachKey visits all keys exactly once and in order', () async {
+    await hivezBox.clear();
+    final entries = <int, int>{};
+    for (var i = 0; i < 140; i++) {
+      entries[i] = i * 4;
+    }
+    await hivezBox.putAll(entries);
+
+    final visitedKeys = <int>[];
+    await hivezBox.foreachKey((key) async {
+      visitedKeys.add(key);
+    });
+
+    final allKeys = (await hivezBox.getAllKeys()).toList();
+    expect(visitedKeys, allKeys);
+    expect(visitedKeys.toSet(), allKeys.toSet());
+  });
+
+  test('foreachValue accumulates sum over many entries', () async {
+    await hivezBox.clear();
+    final entries = <int, int>{};
+    var expectedSum = 0;
+    for (var i = 1; i <= 900; i++) {
+      entries[i] = i;
+      expectedSum += i;
+    }
+    await hivezBox.putAll(entries);
+
+    var sum = 0;
+    await hivezBox.foreachValue((key, value) async {
+      sum += value;
+    });
+    expect(sum, expectedSum);
+  });
+
+  test('foreachValue skips null values for nullable isolated box type',
+      () async {
+    final box = HivezBoxIsolated<int, String?>('nullableIsoBox');
+    await box.ensureInitialized();
+    await box.clear();
+    await box.putAll({
+      1: 'a',
+      2: null,
+      3: 'c',
+      4: null,
+      5: 'e',
+    });
+
+    final seen = <int, String>{};
+    await box.foreachValue((key, value) async {
+      seen[key] = value!;
+    });
+
+    expect(seen.keys.toSet(), {1, 3, 5});
+    expect(seen.values.toSet(), {'a', 'c', 'e'});
+
+    await IsolatedHive.deleteBoxFromDisk('nullableIsoBox');
+  });
+
+  test('foreachKey preserves initial order; may include new keys appended',
+      () async {
+    await hivezBox.clear();
+    await hivezBox.putAll({0: 0, 1: 10, 2: 20, 3: 30});
+
+    final visited = <int>[];
+    await hivezBox.foreachKey((key) async {
+      visited.add(key);
+      if (key == 1) {
+        await hivezBox.put(999, 999);
+      }
+    });
+    expect(visited.take(4).toList(), [0, 1, 2, 3]);
+    expect(visited.length, anyOf(4, 5));
+    if (visited.length == 5) {
+      expect(visited.last, 999);
+    }
+    expect(await hivezBox.containsKey(999), isTrue);
+  });
+
+  test('foreachKey propagates exceptions from action and stops iteration',
+      () async {
+    await hivezBox.clear();
+    await hivezBox.putAll({0: 0, 1: 10, 2: 20, 3: 30});
+
+    var count = 0;
+    Future<void> run() => hivezBox.foreachKey((key) async {
+          count++;
+          if (key == 2) throw StateError('boom');
+        });
+
+    await expectLater(run(), throwsA(isA<StateError>()));
+    expect(count, lessThan(4));
+    expect(count, greaterThanOrEqualTo(3));
+  });
+
   test('moveKey moves value to new key and removes old key', () async {
     await hivezBox.putAll({1: 10});
     final ok = await hivezBox.moveKey(1, 2);

--- a/test/extensions/backup_compressed_isolated_test.dart
+++ b/test/extensions/backup_compressed_isolated_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hive_ce_flutter/adapters.dart';
 
 import '../utils/test_setup.dart';
 

--- a/test/extensions/backup_compressed_test.dart
+++ b/test/extensions/backup_compressed_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hive_ce_flutter/adapters.dart';
 
 import '../utils/test_setup.dart';
 

--- a/test/extensions/backup_json_isolated_test.dart
+++ b/test/extensions/backup_json_isolated_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hive_ce_flutter/adapters.dart';
 import 'package:hivez/hivez.dart';
 
 import '../utils/test_setup.dart';

--- a/test/extensions/backup_json_test.dart
+++ b/test/extensions/backup_json_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hive_ce_flutter/adapters.dart';
 import 'package:hivez/hivez.dart';
 
 import '../utils/test_setup.dart';

--- a/test/extensions/search_isolated_test.dart
+++ b/test/extensions/search_isolated_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hive_ce_flutter/adapters.dart';
 import 'package:hivez/hivez.dart';
 
 import '../utils/test_setup.dart';

--- a/test/extensions/search_test.dart
+++ b/test/extensions/search_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hive_ce_flutter/adapters.dart';
 import 'package:hivez/hivez.dart';
 
 import '../utils/test_setup.dart';


### PR DESCRIPTION
- Added `moveKey` method to reassign a value from one key to another (renames the key while preserving the value).
- Added `foreachKey` and `foreachValue` methods to iterate over all keys and values in the box
- Made the base `BoxInterface` class simpler for better abstraction and flexibility
- Added exports from `hive_ce` to the package for ease of use
- Updated the **README** with more detailed examples and better structure with sections Features, Hive vs `Hivez` Comparison, How to Use `Hivez`, Examples, Setup Guide for `hive_ce`